### PR TITLE
Bump: Maven Assembly, Shade plugins, Mockito and CheckStyle minor updates

### DIFF
--- a/Base/Versions/pom.xml
+++ b/Base/Versions/pom.xml
@@ -20,7 +20,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>17</java.version>
 		<maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
-		<maven-assembly-plugin.version>3.6.0</maven-assembly-plugin.version>
+		<maven-assembly-plugin.version>3.7.0</maven-assembly-plugin.version>
 		<maven-dependency-plugin.version>3.6.1</maven-dependency-plugin.version>
 		<maven-release-plugin.version>3.0.1</maven-release-plugin.version>
 		<maven-clean-plugin.version>3.3.2</maven-clean-plugin.version>

--- a/Base/pom.xml
+++ b/Base/pom.xml
@@ -23,20 +23,20 @@
 		<spotbugs-annotations.version>4.8.3</spotbugs-annotations.version>
 		<hamcrest.version>2.2</hamcrest.version>
 		<junit.version>5.10.2</junit.version>
-		<mockito.version>5.10.0</mockito.version>
+		<mockito.version>5.11.0</mockito.version>
 		<!-- pluginManagement -->
 		<maven-enforcer-plugin.version>3.4.1</maven-enforcer-plugin.version>
 		<maven-surefire-report-plugin.version>3.2.5</maven-surefire-report-plugin.version>
 		<maven-failsafe-plugin.version>3.2.5</maven-failsafe-plugin.version>
 		<maven-javadoc-plugin.version>3.6.3</maven-javadoc-plugin.version>
-		<maven-shade-plugin.version>3.5.1</maven-shade-plugin.version>
+		<maven-shade-plugin.version>3.5.2</maven-shade-plugin.version>
 		<editorconfig-maven-plugin.version>0.1.3</editorconfig-maven-plugin.version>
 		<maven-pmd-plugin.version>3.21.2</maven-pmd-plugin.version>
 		<pmd-core.version>6.55.0</pmd-core.version>
 		<pmd-java.version>6.55.0</pmd-java.version>
 		<spotbugs-maven-plugin.version>4.8.3.1</spotbugs-maven-plugin.version>
 		<maven-checkstyle-plugin.version>3.3.1</maven-checkstyle-plugin.version>
-		<checkstyle.version>10.13.0</checkstyle.version>
+		<checkstyle.version>10.14.1</checkstyle.version>
 		<maven-project-info-reports-plugin.version>3.5.0</maven-project-info-reports-plugin.version>
 		<maven-jxr-plugin.version>3.3.2</maven-jxr-plugin.version>
 		<cobertura-maven-plugin.version>2.7</cobertura-maven-plugin.version>

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ help: ## This help.
 
 # Updates of third-party dependencies
 update-dependencies: ## Update Maven dependencies and plugins which have versions defined in properties
-	.mvn/mvnw --projects :base,:versions clean versions:update-properties
+	cd Base && ../mvnw --projects :base,:versions clean versions:update-properties
 
 update-snapshot-dependencies: ## Update locked snapshot versions with the latest available one in the POM
-	.mvn/mvnw --projects :base,:versions versions:unlock-snapshots versions:lock-snapshots
+	cd Base && ../mvnw --projects :base,:versions versions:unlock-snapshots versions:lock-snapshots


### PR DESCRIPTION
Now first time indirectly through the new MavenSetup submodule.  
\(ReBuild is used to verify those minor version bumps, and other consumers of MavenSetup \(like JuicyRaspberryPie soon\) will get those, too.\)  

* c144c5e Makefile: Adapt: Move Makefile one dir up and adapt path to mvnw  

Within ReBuild, the Makefile still had to be within the `Base` subdir, as there's already `ReBuild/Makefile`; now that this is a separate repository, let's make this more discoverable and put in into the repo root.  
The path to `mvnw` needs to be adapted, anyway.  

Server: `rebuild-bump-versions.dev-join.reload.works`

---
<!-- Git and GitHub -->
- [ ] The main commit(s) reference the Fibery ticket via a `TASK-NNNN` prefix in the commit message subject
- [X] Include a human-readable description of what the pull request is trying to accomplish
- [X] The CI build passes
---
<!-- Testing; only one of the following needs to be checked: -->
- [ ] New automated tests have been added
- [ ] The changes are already covered by automated tests and have been adapted
- [ ] These manual test cases cover this change:
- [ ] Steps for the reviewer(s) on how they can manually QA the changes:
- [X] This is a minor internal change; basic CI/CD coverage is enough
- [ ] This is an incomplete feature hidden behind feature flag:
- [ ] This is proof-of-concept / experimental code not for production / marked `@Deprecated`
- [X] No (significant) changes to production code
<!-- Development -->
- [ ] The change also works in LogicTestServer (and does not break it)
- [ ] The change also works in the local Docker Compose environment
- [ ] The change also works under Bedrock edition
---
<!-- Documentation -->
- [ ] Classes and public methods have documentation (that doesn't just repeat the technical subject in English)
- [ ] Logging is implemented to monitor feature usage and troubleshoot problems in production
- [ ] These ReWiki pages are affected by this change and will be adapted: