### PR TITLE
TASK-4017 moved banned dependencies defined in the base pom.xml to th…

### DIFF
--- a/Base/pom.xml
+++ b/Base/pom.xml
@@ -326,6 +326,35 @@
 							</rules>
 						</configuration>
 					</execution>
+					<!--
+						Banned dependencies are not allowed in the project, and may cause build failures or unexpected behavior.
+						This is due to conflicts between banned dependencies and existing project dependencies.
+						For example, a banned dependency may be an older version of a project dependency,
+						but with a different groupId or artifactId, making it difficult for Maven to detect the conflict
+						and choose the correct dependency.
+					-->
+					<execution>
+						<id>enforce-banned-dependencies-from-base</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<bannedDependencies>
+									<excludes>
+										<!-- We use com.github.spotbugs, the successor of FindBugs. -->
+										<exclude>com.google.code.findbugs</exclude>
+										<!-- We use org.junit.jupiter; previous versions (i.e. JUnit 4) should never be referenced. -->
+										<exclude>junit</exclude>
+									</excludes>
+									<includes>
+										<!-- SpotBugs still references the jsr305 Artifact from the original FindBugs. -->
+										<include>com.google.code.findbugs:jsr305</include>
+									</includes>
+								</bannedDependencies>
+							</rules>
+						</configuration>
+					</execution>
 				</executions>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
…e base instead of having them in ReBuild

<!-- TODO: Please describe your changes here. -->

---
<!-- Git and GitHub -->
- [x] The main commit(s) reference the Fibery ticket via a `TASK-NNNN` prefix in the commit message subject
- [x] Include a human-readable description of what the pull request is trying to accomplish
- [x] The CI build passes
---
<!-- Testing; only one of the following needs to be checked: -->
- [ ] New automated tests have been added
- [ ] The changes are already covered by automated tests and have been adapted
- [ ] These manual test cases cover this change:
- [ ] Steps for the reviewer(s) on how they can manually QA the changes:
- [ ] This is a minor internal change; basic CI/CD coverage is enough
- [ ] This is an incomplete feature hidden behind feature flag:
- [ ] This is proof-of-concept / experimental code not for production / marked `@Deprecated`
- [ ] No (significant) changes to production code
<!-- Development -->
- [ ] The change also works in LogicTestServer (and does not break it)
- [ ] The change also works in the local Docker Compose environment
- [ ] The change also works under Bedrock edition
---
<!-- Documentation -->
- [ ] Classes and public methods have documentation (that doesn't just repeat the technical subject in English)
- [ ] Logging is implemented to monitor feature usage and troubleshoot problems in production
- [ ] These ReWiki pages are affected by this change and will be adapted:
