### PR TITLE
FIX: Adapt: update[-snapshot]-dependencies broken, and don't create pom.xml.versionsBackup on dependency updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,12 +9,14 @@ help: ## This help.
 
 .DEFAULT_GOAL := help
 
+MAVEN_COMMAND ?= ./mvnw
+
 # Updates of third-party dependencies
 update-dependencies: ## Update Maven dependencies and plugins which have versions defined in properties
-	./mvnw --projects :base,:versions clean -DgenerateBackupPoms=false versions:update-properties
+	$(MAVEN_COMMAND) --projects :base,:versions clean -DgenerateBackupPoms=false versions:update-properties
 
 update-snapshot-dependencies: ## Update locked snapshot versions with the latest available one in the POM
-	./mvnw --projects :base,:versions -DgenerateBackupPoms=false versions:unlock-snapshots versions:lock-snapshots
+	$(MAVEN_COMMAND) --projects :base,:versions -DgenerateBackupPoms=false versions:unlock-snapshots versions:lock-snapshots
 
 bump-version: ## Bump the version of the project
-	[ -n "$(NEW_VERSION)" ] && ./mvnw versions:set-property -DgenerateBackupPoms=false -Dproperty=revision -DnewVersion=$(NEW_VERSION)
+	[ -n "$(NEW_VERSION)" ] && $(MAVEN_COMMAND) versions:set-property -DgenerateBackupPoms=false -Dproperty=revision -DnewVersion=$(NEW_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,10 @@ help: ## This help.
 
 # Updates of third-party dependencies
 update-dependencies: ## Update Maven dependencies and plugins which have versions defined in properties
-	./mvnw --projects :base,:versions clean versions:update-properties
+	./mvnw --projects :base,:versions clean -DgenerateBackupPoms=false versions:update-properties
 
 update-snapshot-dependencies: ## Update locked snapshot versions with the latest available one in the POM
-	./mvnw --projects :base,:versions versions:unlock-snapshots versions:lock-snapshots
+	./mvnw --projects :base,:versions -DgenerateBackupPoms=false versions:unlock-snapshots versions:lock-snapshots
 
 bump-version: ## Bump the version of the project
 	[ -n "$(NEW_VERSION)" ] && ./mvnw versions:set-property -DgenerateBackupPoms=false -Dproperty=revision -DnewVersion=$(NEW_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -19,4 +19,5 @@ update-snapshot-dependencies: ## Update locked snapshot versions with the latest
 	$(MAVEN_COMMAND) --projects :parent,:versions -DgenerateBackupPoms=false versions:unlock-snapshots versions:lock-snapshots
 
 bump-version: ## Bump the version of the project
-	[ -n "$(NEW_VERSION)" ] && $(MAVEN_COMMAND) versions:set-property -DgenerateBackupPoms=false -Dproperty=revision -DnewVersion=$(NEW_VERSION)
+	if [ -z "$(NEW_VERSION)" ]; then echo 'ERROR: NEW_VERSION is not set.'; exit 2; fi
+	$(MAVEN_COMMAND) versions:set-property -DgenerateBackupPoms=false -Dproperty=revision -DnewVersion=$(NEW_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,10 @@ MAVEN_COMMAND ?= ./mvnw
 
 # Updates of third-party dependencies
 update-dependencies: ## Update Maven dependencies and plugins which have versions defined in properties
-	$(MAVEN_COMMAND) --projects :base,:versions clean -DgenerateBackupPoms=false versions:update-properties
+	$(MAVEN_COMMAND) --projects :parent,:versions clean -DgenerateBackupPoms=false versions:update-properties
 
 update-snapshot-dependencies: ## Update locked snapshot versions with the latest available one in the POM
-	$(MAVEN_COMMAND) --projects :base,:versions -DgenerateBackupPoms=false versions:unlock-snapshots versions:lock-snapshots
+	$(MAVEN_COMMAND) --projects :parent,:versions -DgenerateBackupPoms=false versions:unlock-snapshots versions:lock-snapshots
 
 bump-version: ## Bump the version of the project
 	[ -n "$(NEW_VERSION)" ] && $(MAVEN_COMMAND) versions:set-property -DgenerateBackupPoms=false -Dproperty=revision -DnewVersion=$(NEW_VERSION)

--- a/pom.xml
+++ b/pom.xml
@@ -489,6 +489,7 @@
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>versions-maven-plugin</artifactId>
 				<configuration>
+					<excludeProperties>changelist</excludeProperties>
 					<ruleSet>
 						<rules>
 							<!-- We'll upgrade to PMD 7 once it's released. -->


### PR DESCRIPTION
* c3c5b54 Makefile: Minor: Factor out MAVEN\_COMMAND to allow customization  
* 60dce76 Housekeeping: FIX: make update-dependencies puts the revision into <changelist>

---
<!-- Git and GitHub -->
- [ ] The main commit(s) reference the Fibery ticket via a `TASK-NNNN` prefix in the commit message subject
- [X] Include a human-readable description of what the pull request is trying to accomplish
- [X] The CI build passes
---
<!-- Testing; only one of the following needs to be checked: -->
- [ ] New automated tests have been added
- [ ] The changes are already covered by automated tests and have been adapted
- [ ] These manual test cases cover this change:
- [ ] Steps for the reviewer(s) on how they can manually QA the changes:
- [X] This is a minor internal change; basic CI/CD coverage is enough
- [ ] This is an incomplete feature hidden behind feature flag:
- [ ] This is proof-of-concept / experimental code not for production / marked `@Deprecated`
- [X] No (significant) changes to production code
---
<!-- Documentation -->
- [ ] Classes and public methods have documentation (that doesn't just repeat the technical subject in English)
- [ ] Logging is implemented to monitor feature usage and troubleshoot problems in production
- [ ] These ReWiki pages are affected by this change and will be adapted: