### PR TITLE
XXX: Use updated 2.2.2 linter with editorconfig-maven-plugin 0.1.3 for the fixed .idea default exclude

### DIFF
--- a/configs/pom.xml
+++ b/configs/pom.xml
@@ -16,7 +16,7 @@
 
 	<properties>
 		<!-- project version -->
-		<revision>1.2.0</revision>
+		<revision>1.2.1</revision>
 		<changelist>-SNAPSHOT</changelist>
 	</properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
 	<properties>
 		<!-- project version -->
-		<revision>1.2.0</revision>
+		<revision>1.2.1</revision>
 		<changelist>-SNAPSHOT</changelist>
 		<!-- dependencyManagement versions -->
 		<jetbrains-annotations.version>24.1.0</jetbrains-annotations.version>
@@ -33,7 +33,8 @@
 		<maven-source-plugin.version>3.3.1</maven-source-plugin.version>
 		<maven-javadoc-plugin.version>3.6.3</maven-javadoc-plugin.version>
 		<maven-shade-plugin.version>3.5.3</maven-shade-plugin.version>
-		<editorconfig-maven-plugin.version>0.1.3</editorconfig-maven-plugin.version>
+		<editorconfig-maven-plugin.version>0.1.3</editorconfig-maven-plugin.version> <!-- XXX: Remove linter dependency overrides when
+		upgrading from 0.1.3 -->
 		<maven-pmd-plugin.version>3.22.0</maven-pmd-plugin.version>
 		<pmd-core.version>7.1.0</pmd-core.version>
 		<pmd-java.version>7.1.0</pmd-java.version>
@@ -215,6 +216,19 @@
 							</goals>
 						</execution>
 					</executions>
+					<dependencies>
+						<!-- Use updated 2.2.2 linter with editorconfig-maven-plugin 0.1.3 for the fixed .idea default exclude. -->
+						<dependency>
+							<groupId>org.ec4j.linters</groupId>
+							<artifactId>editorconfig-lint-api</artifactId>
+							<version>2.2.2</version>
+						</dependency>
+						<dependency>
+							<groupId>org.ec4j.linters</groupId>
+							<artifactId>editorconfig-linters</artifactId>
+							<version>2.2.2</version>
+						</dependency>
+					</dependencies>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>

--- a/versions/pom.xml
+++ b/versions/pom.xml
@@ -18,7 +18,7 @@
 
 	<properties>
 		<!-- project version -->
-		<revision>1.2.0</revision>
+		<revision>1.2.1</revision>
 		<changelist>-SNAPSHOT</changelist>
 		<!-- project settings -->
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Python development is hampered by EditorConfig complaining about violations in .idea directories when they are not directly in the repo root.  
This got fixed in https://github.com/ec4j/editorconfig-linters/pull/25, but no editorconfig-maven-plugin has been released; only the dependencies themselves.  

---
<!-- Git and GitHub -->
- [ ] The main commit(s) reference the Fibery ticket via a `TASK-NNNN` prefix in the commit message subject
- [X] Include a human-readable description of what the pull request is trying to accomplish
- [X] The CI build passes
---
<!-- Testing; only one of the following needs to be checked: -->
- [ ] New automated tests have been added
- [ ] The changes are already covered by automated tests and have been adapted
- [ ] These manual test cases cover this change:
- [ ] Steps for the reviewer(s) on how they can manually QA the changes:
- [X] This is a minor internal change; basic CI/CD coverage is enough
- [ ] This is an incomplete feature hidden behind feature flag:
- [ ] This is proof-of-concept / experimental code not for production / marked `@Deprecated`
- [X] No (significant) changes to production code
---
<!-- Documentation -->
- [ ] Classes and public methods have documentation (that doesn't just repeat the technical subject in English)
- [ ] Logging is implemented to monitor feature usage and troubleshoot problems in production
- [ ] These ReWiki pages are affected by this change and will be adapted: