### PR TITLE
TASK-4121 Also build JavaDocs, Maven Site, and upload the latter to Google Cloud

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
   build_feature_branch:
     name: Build feature branch
     runs-on: ubuntu-latest
-    if: "github.ref != 'refs/heads/main'"
+    if: github.ref != 'refs/heads/main'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -33,16 +33,16 @@ jobs:
       - name: Setup Java and Maven
         uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
+          distribution: temurin
           java-version: 21
-          cache: 'maven'
+          cache: maven
       - name: Build with Maven verify
         run: |
           ./mvnw --batch-mode verify javadoc:javadoc javadoc:aggregate
   build_main_branch:
     name: Build main branch
     runs-on: ubuntu-latest
-    if: "github.ref == 'refs/heads/main'"
+    if: github.ref == 'refs/heads/main'
     outputs:
       release-version: ${{ steps.set-version.outputs.release-version }}
     steps:
@@ -54,10 +54,10 @@ jobs:
       - name: Setup Java and Maven
         uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
+          distribution: temurin
           java-version: 21
           cache: 'maven'
-          server-id: 'reload'
+          server-id: reload
           server-username: MAVEN_SERVER_USERNAME
           server-password: MAVEN_SERVER_PASSWORD
       - name: Read revision version from pom.xml
@@ -77,7 +77,7 @@ jobs:
           fi
 
       - name: Build with Maven deploy
-        if: ${{ env.DEPLOY_RELEASE  == 'true' }}
+        if: env.DEPLOY_RELEASE  == 'true'
         env:
           MAVEN_SERVER_USERNAME: ${{ secrets.MAVEN_SERVER_USERNAME }}
           MAVEN_SERVER_PASSWORD: ${{ secrets.MAVEN_SERVER_PASSWORD }}
@@ -87,7 +87,7 @@ jobs:
           rm -rf -- "${GITHUB_WORKSPACE}/target/${MAVEN_POM_REVISION_VERSION}" || :
           cp --recursive --verbose -- "${GITHUB_WORKSPACE}/target/latest" "${GITHUB_WORKSPACE}/target/${MAVEN_POM_REVISION_VERSION}"
       - name: Create new git tag
-        if: ${{ env.DEPLOY_RELEASE  == 'true' }}
+        if: env.DEPLOY_RELEASE  == 'true'
         uses: rickstaa/action-create-tag@v1
         with:
           tag: ${{ env.MAVEN_POM_REVISION_VERSION }}
@@ -100,7 +100,7 @@ jobs:
       - name: Authenticate with Google Cloud
         uses: google-github-actions/auth@v1
         with:
-          credentials_json: '${{ secrets.CLOUDBUILD_COMMON_GCP_KEY }}'
+          credentials_json: ${{ secrets.CLOUDBUILD_COMMON_GCP_KEY }}
       - name: Upload latest JavaDoc copy to Google Cloud Storage
         uses: google-github-actions/upload-cloud-storage@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,11 @@ on:
   workflow_dispatch:
   # Allows reuse of this workflow as a generic "Java build with Maven that publishes to main on merge"
   workflow_call:
+    inputs:
+      javadoc-project-name:
+        description: Project subdirectory to upload the JavaDoc to in Google Cloud Storage.
+        required: true
+        type: string
     outputs:
       release-version:
         description: The version of the new release built on the main branch.
@@ -69,18 +74,42 @@ jobs:
             DEPLOY_RELEASE=true
             echo "DEPLOY_RELEASE=$DEPLOY_RELEASE" >> $GITHUB_ENV
           fi
+
       - name: Build with Maven deploy
         if: ${{ env.DEPLOY_RELEASE  == 'true' }}
-        run: ./mvnw -Dchangelist= -B deploy site:site site:stage
         env:
           MAVEN_SERVER_USERNAME: ${{ secrets.MAVEN_SERVER_USERNAME }}
           MAVEN_SERVER_PASSWORD: ${{ secrets.MAVEN_SERVER_PASSWORD }}
+        run: |
+          ./mvnw -Dchangelist= --batch-mode deploy -DstagingDirectory="${GITHUB_WORKSPACE}/target/latest" site:site site:stage
+          test -d "${GITHUB_WORKSPACE}/target/latest"
+          rm -rf -- "${GITHUB_WORKSPACE}/target/${MAVEN_POM_REVISION_VERSION}" || :
+          cp --recursive --verbose -- "${GITHUB_WORKSPACE}/target/latest" "${GITHUB_WORKSPACE}/target/${MAVEN_POM_REVISION_VERSION}"
       - name: Create new git tag
-        uses: rickstaa/action-create-tag@v1
         if: ${{ env.DEPLOY_RELEASE  == 'true' }}
+        uses: rickstaa/action-create-tag@v1
         with:
           tag: ${{ env.MAVEN_POM_REVISION_VERSION }}
           message: Release ${{ env.MAVEN_POM_REVISION_VERSION }}
       - name: Set version output
         id: set-version
+        if: env.DEPLOY_RELEASE  == 'true'
         run: echo "release-version=${MAVEN_POM_REVISION_VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Authenticate with Google Cloud
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: '${{ secrets.CLOUDBUILD_COMMON_GCP_KEY }}'
+      - name: Upload latest JavaDoc copy to Google Cloud Storage
+        uses: google-github-actions/upload-cloud-storage@v1
+        with:
+          path: target/latest
+          destination: resilient-reload-javadoc/${{ inputs.javadoc-project-name || 'MavenSetup' }}
+          process_gcloudignore: false
+      - name: Upload versioned JavaDoc to Google Cloud Storage
+        if: env.DEPLOY_RELEASE  == 'true'
+        uses: google-github-actions/upload-cloud-storage@v1
+        with:
+          path: target/${{ env.MAVEN_POM_REVISION_VERSION }}
+          destination: resilient-reload-javadoc/${{ inputs.javadoc-project-name || 'MavenSetup' }}
+          process_gcloudignore: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,8 @@ jobs:
           java-version: 21
           cache: 'maven'
       - name: Build with Maven verify
-        run: ./mvnw -B verify
+        run: |
+          ./mvnw --batch-mode verify javadoc:javadoc javadoc:aggregate
   build_main_branch:
     name: Build main branch
     runs-on: ubuntu-latest
@@ -62,7 +63,7 @@ jobs:
       - name: Read revision version from pom.xml
         shell: bash
         run: |
-          MAVEN_POM_REVISION_VERSION="$(./mvnw help:evaluate -Dexpression=revision -q -DforceStdout)"
+          MAVEN_POM_REVISION_VERSION="$(./mvnw --batch-mode help:evaluate -Dexpression=revision -q -DforceStdout)"
           echo "MAVEN_POM_REVISION_VERSION=$MAVEN_POM_REVISION_VERSION" >> $GITHUB_ENV
       - name: Check if revision is already tagged
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,11 @@ jobs:
             echo "DEPLOY_RELEASE=$DEPLOY_RELEASE" >> $GITHUB_ENV
           fi
 
-      - name: Build with Maven deploy
+      - name: Build merged feature without releasing it
+        if: env.DEPLOY_RELEASE  != 'true'
+        run: |
+          ./mvnw -Dchangelist= --batch-mode verify -DstagingDirectory="${GITHUB_WORKSPACE}/target/latest" site:site site:stage
+      - name: Build and deploy new release
         if: env.DEPLOY_RELEASE  == 'true'
         env:
           MAVEN_SERVER_USERNAME: ${{ secrets.MAVEN_SERVER_USERNAME }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,10 @@ on:
   workflow_dispatch:
   # Allows reuse of this workflow as a generic "Java build with Maven that publishes to main on merge"
   workflow_call:
+    outputs:
+      release-version:
+        description: The version of the new release built on the main branch.
+        value: ${{ jobs.build_main_branch.outputs.release-version }}
 
 jobs:
   build_feature_branch:
@@ -33,6 +37,8 @@ jobs:
     name: Build main branch
     runs-on: ubuntu-latest
     if: "github.ref == 'refs/heads/main'"
+    outputs:
+      release-version: ${{ steps.set-version.outputs.release-version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -75,3 +81,6 @@ jobs:
         with:
           tag: ${{ env.MAVEN_POM_REVISION_VERSION }}
           message: Release ${{ env.MAVEN_POM_REVISION_VERSION }}
+      - name: Set version output
+        id: set-version
+        run: echo "release-version=${MAVEN_POM_REVISION_VERSION}" >> $GITHUB_OUTPUT

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
           fi
       - name: Build with Maven deploy
         if: ${{ env.DEPLOY_RELEASE  == 'true' }}
-        run: ./mvnw -Dchangelist= -B deploy
+        run: ./mvnw -Dchangelist= -B deploy site:site site:stage
         env:
           MAVEN_SERVER_USERNAME: ${{ secrets.MAVEN_SERVER_USERNAME }}
           MAVEN_SERVER_PASSWORD: ${{ secrets.MAVEN_SERVER_PASSWORD }}

--- a/configs/pom.xml
+++ b/configs/pom.xml
@@ -16,7 +16,7 @@
 
 	<properties>
 		<!-- project version -->
-		<revision>1.3.2</revision>
+		<revision>1.4.0</revision>
 		<changelist>-SNAPSHOT</changelist>
 	</properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
 	<properties>
 		<!-- project version -->
-		<revision>1.3.2</revision>
+		<revision>1.4.0</revision>
 		<changelist>-SNAPSHOT</changelist>
 		<!-- dependencyManagement versions -->
 		<jetbrains-annotations.version>24.1.0</jetbrains-annotations.version>

--- a/versions/pom.xml
+++ b/versions/pom.xml
@@ -18,7 +18,7 @@
 
 	<properties>
 		<!-- project version -->
-		<revision>1.3.2</revision>
+		<revision>1.4.0</revision>
 		<changelist>-SNAPSHOT</changelist>
 		<!-- project settings -->
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
This aligns the MavenSetup with what we've implemented in ReBuild, adding the JavaDoc build for feature branches (now that JuicyRaspberryPie additions have proper documentation), building the complete site reports, and uploading that to https://javadocs.dev.reload.works/
This allows users of the reusable workflow (like JuicyRaspberryPie, and eventually also plugins extracted from ReBuild) to publish their documentation.

---
<!-- Git and GitHub -->
- [X] The main commit(s) reference the Fibery ticket via a `TASK-NNNN` prefix in the commit message subject
- [X] Include a human-readable description of what the pull request is trying to accomplish
- [X] The CI build passes
---
<!-- Testing; only one of the following needs to be checked: -->
- [ ] New automated tests have been added
- [ ] The changes are already covered by automated tests and have been adapted
- [ ] These manual test cases cover this change:
- [X] Steps for the reviewer(s) on how they can manually QA the changes:
  - [X] MavenSetup site has been built and uploaded as a trial
  - [X] JuicyRaspberryPie successfully consumed the workflow
- [X] This is a minor internal change; basic CI/CD coverage is enough
- [ ] This is an incomplete feature hidden behind feature flag:
- [ ] This is proof-of-concept / experimental code not for production / marked `@Deprecated`
- [X] No (significant) changes to production code
---
<!-- Documentation -->
- [ ] Classes and public methods have documentation (that doesn't just repeat the technical subject in English)
- [ ] Logging is implemented to monitor feature usage and troubleshoot problems in production
- [ ] These ReWiki pages are affected by this change and will be adapted: