### PR TITLE
Robustness: Deploy to Maven repo only after successful verification and site build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,16 +80,20 @@ jobs:
         if: env.DEPLOY_RELEASE  != 'true'
         run: |
           ./mvnw -Dchangelist= --batch-mode verify -DstagingDirectory="${GITHUB_WORKSPACE}/target/latest" site:site site:stage
-      - name: Build and deploy new release
+      - name: Build new release
+        if: env.DEPLOY_RELEASE  == 'true'
+        run: |
+          ./mvnw -Dchangelist= --batch-mode verify -DstagingDirectory="${GITHUB_WORKSPACE}/target/latest" site:site site:stage
+          test -d "${GITHUB_WORKSPACE}/target/latest"
+          rm -rf -- "${GITHUB_WORKSPACE}/target/${MAVEN_POM_REVISION_VERSION}" || :
+          cp --recursive --verbose -- "${GITHUB_WORKSPACE}/target/latest" "${GITHUB_WORKSPACE}/target/${MAVEN_POM_REVISION_VERSION}"
+      - name: Deploy new release
         if: env.DEPLOY_RELEASE  == 'true'
         env:
           MAVEN_SERVER_USERNAME: ${{ secrets.MAVEN_SERVER_USERNAME }}
           MAVEN_SERVER_PASSWORD: ${{ secrets.MAVEN_SERVER_PASSWORD }}
         run: |
-          ./mvnw -Dchangelist= --batch-mode deploy -DstagingDirectory="${GITHUB_WORKSPACE}/target/latest" site:site site:stage
-          test -d "${GITHUB_WORKSPACE}/target/latest"
-          rm -rf -- "${GITHUB_WORKSPACE}/target/${MAVEN_POM_REVISION_VERSION}" || :
-          cp --recursive --verbose -- "${GITHUB_WORKSPACE}/target/latest" "${GITHUB_WORKSPACE}/target/${MAVEN_POM_REVISION_VERSION}"
+          ./mvnw -Dchangelist= --batch-mode deploy
       - name: Create new git tag
         if: env.DEPLOY_RELEASE  == 'true'
         uses: rickstaa/action-create-tag@v1

--- a/configs/pom.xml
+++ b/configs/pom.xml
@@ -16,7 +16,7 @@
 
 	<properties>
 		<!-- project version -->
-		<revision>1.7.0</revision>
+		<revision>1.7.1</revision>
 		<changelist>-SNAPSHOT</changelist>
 	</properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
 	<properties>
 		<!-- project version -->
-		<revision>1.7.0</revision>
+		<revision>1.7.1</revision>
 		<changelist>-SNAPSHOT</changelist>
 		<!-- dependencyManagement versions -->
 		<jetbrains-annotations.version>24.1.0</jetbrains-annotations.version>

--- a/versions/pom.xml
+++ b/versions/pom.xml
@@ -18,7 +18,7 @@
 
 	<properties>
 		<!-- project version -->
-		<revision>1.7.0</revision>
+		<revision>1.7.1</revision>
 		<changelist>-SNAPSHOT</changelist>
 		<!-- project settings -->
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
As deployment is part of the default lifecycle, it happens before the site \(which is a different lifecycle\) is built and staged.  
A flaky connection to our Maven repo caused a build to fail while downloading Maven plugins required for the site build; i.e. the build failed \_after\_ the artifact had already been deployed.  
Subsequent reruns then failed because the Maven artifact had already been deployed \(and a Nexus repo doesn't allow a redeploy by default - the artifact needs to be manually deleted first\):  
> Error:  Failed to execute goal org.apache.maven.plugins:maven-deploy-plugin:3.1.2:deploy (default-deploy) on project juicyraspberrypie: Failed to deploy artifacts: Could not transfer artifact org.wensheng:juicyraspberrypie:pom:2.1.5 from/to reload (https://nexus.reloadkube.managedservices.resilient-teched.com/repository/reload/): status code: 400, reason phrase: Repository does not allow updating assets: reload (400) -> [Help 1]
It's better to first do all build steps \(including the site\), and only then do the deployment separately.  

---
<!-- Git and GitHub -->
- [ ] The main commit(s) reference the Fibery ticket via a `TASK-NNNN` prefix in the commit message subject
- [X] Include a human-readable description of what the pull request is trying to accomplish
- [X] The CI build passes
---
<!-- Testing; only one of the following needs to be checked: -->
- [ ] New automated tests have been added
- [ ] The changes are already covered by automated tests and have been adapted
- [ ] These manual test cases cover this change:
- [ ] Steps for the reviewer(s) on how they can manually QA the changes:
- [X] This is a minor internal change; basic CI/CD coverage is enough
- [ ] This is an incomplete feature hidden behind feature flag:
- [ ] This is proof-of-concept / experimental code not for production / marked `@Deprecated`
- [X] No (significant) changes to production code
- [X] This can only be fully tested after merging
---
<!-- Documentation -->
- [ ] ~~Classes and public methods have documentation (that doesn't just repeat the technical subject in English)~~
- [ ] ~~Logging is implemented to monitor feature usage and troubleshoot problems in production~~
- [ ] ~~These ReWiki pages are affected by this change and will be adapted:~~