### PR TITLE
TASK-4335 BUG: Shaded plugin artifact is neither installed nor deployed

### DIFF
--- a/configs/pom.xml
+++ b/configs/pom.xml
@@ -16,7 +16,7 @@
 
 	<properties>
 		<!-- project version -->
-		<revision>1.7.1</revision>
+		<revision>1.7.2</revision>
 		<changelist>-SNAPSHOT</changelist>
 	</properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -467,7 +467,7 @@
 							<shadedArtifactId>${project.name}</shadedArtifactId>
 							<createDependencyReducedPom>false</createDependencyReducedPom>
 							<shadedArtifactAttached>true</shadedArtifactAttached>
-							<outputFile>${project.build.directory}/${project.build.finalName}-shaded.jar</outputFile>
+							<shadedClassifierName>shaded</shadedClassifierName>
 							<artifactSet>
 								<excludes>
 									<exclude>com.github.spotbugs:spotbugs-annotations</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
 	<properties>
 		<!-- project version -->
-		<revision>1.7.1</revision>
+		<revision>1.7.2</revision>
 		<changelist>-SNAPSHOT</changelist>
 		<!-- dependencyManagement versions -->
 		<jetbrains-annotations.version>24.1.0</jetbrains-annotations.version>

--- a/versions/pom.xml
+++ b/versions/pom.xml
@@ -18,7 +18,7 @@
 
 	<properties>
 		<!-- project version -->
-		<revision>1.7.1</revision>
+		<revision>1.7.2</revision>
 		<changelist>-SNAPSHOT</changelist>
 		<!-- project settings -->
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Both local and remote Maven repos just contain the unshaded JAR. The shaded JAR only exists locally in the target folder.  
For JuicyRaspberryPie this wasn't important, as there are no external dependencies that need to be shaded so far. But we're going to consume the ReLoAd family plugins now via the Maven repo as well, and those do have shading.  
To have both original and shaded artifact, it needs to be attached; cp. https://maven.apache.org/plugins/maven-shade-plugin/examples/attached-artifact.html  
The configuration already enabled `<shadedArtifactAttached>`, but didn't specify the `<shadedClassifierName>`. (I couldn't find any documentation whether there's a default for that, but the example specifies it.)
Additionally, the (also not documented) `<outputFile>` prevents the install; cp. https://stackoverflow.com/a/67112650/813602

---
<!-- Git and GitHub -->
- [X] The main commit(s) reference the Fibery ticket via a `TASK-NNNN` prefix in the commit message subject
- [X] Include a human-readable description of what the pull request is trying to accomplish
- [X] The CI build passes
---
<!-- Testing; only one of the following needs to be checked: -->
- [ ] New automated tests have been added
- [ ] The changes are already covered by automated tests and have been adapted
- [ ] These manual test cases cover this change:
- [X] Steps for the reviewer(s) on how they can manually QA the changes:
  - [X] Build JuicyRaspberryPie with the updated parent
- [ ] This is a minor internal change; basic CI/CD coverage is enough
- [ ] This is an incomplete feature hidden behind feature flag:
- [ ] This is proof-of-concept / experimental code not for production / marked `@Deprecated`
- [ ] No (significant) changes to production code
---
<!-- Documentation -->
- [ ] ~~Classes and public methods have documentation (that doesn't just repeat the technical subject in English)~~
- [ ] ~~Logging is implemented to monitor feature usage and troubleshoot problems in production~~
- [ ] ~~These ReWiki pages are affected by this change and will be adapted:~~