### PR TITLE
Build: Refactoring: Deduplicate the used JDK version by reading it from the POM

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,11 +30,14 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+      - name: Determine Java version
+        uses: joshlong/java-version-export-github-action@v28
+        id: determine-java-version
       - name: Setup Java and Maven
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 21
+          java-version: ${{ steps.determine-java-version.outputs.java_major_version }}
           cache: maven
       - name: Build with Maven verify
         run: |
@@ -51,11 +54,14 @@ jobs:
         with:
           fetch-depth: 0
           submodules: true
+      - name: Determine Java version
+        uses: joshlong/java-version-export-github-action@v28
+        id: determine-java-version
       - name: Setup Java and Maven
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 21
+          java-version: ${{ steps.determine-java-version.outputs.java_major_version }}
           cache: 'maven'
           server-id: reload
           server-username: MAVEN_SERVER_USERNAME

--- a/configs/pom.xml
+++ b/configs/pom.xml
@@ -16,7 +16,7 @@
 
 	<properties>
 		<!-- project version -->
-		<revision>1.7.3</revision>
+		<revision>1.7.4</revision>
 		<changelist>-SNAPSHOT</changelist>
 	</properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
 	<properties>
 		<!-- project version -->
-		<revision>1.7.3</revision>
+		<revision>1.7.4</revision>
 		<changelist>-SNAPSHOT</changelist>
 		<!-- dependencyManagement versions -->
 		<jetbrains-annotations.version>24.1.0</jetbrains-annotations.version>

--- a/versions/pom.xml
+++ b/versions/pom.xml
@@ -18,7 +18,7 @@
 
 	<properties>
 		<!-- project version -->
-		<revision>1.7.3</revision>
+		<revision>1.7.4</revision>
 		<changelist>-SNAPSHOT</changelist>
 		<!-- project settings -->
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/versions/pom.xml
+++ b/versions/pom.xml
@@ -22,7 +22,7 @@
 		<changelist>-SNAPSHOT</changelist>
 		<!-- project settings -->
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<java.version>21</java.version>
+		<maven.compiler.target>21</maven.compiler.target>
 		<!-- plugin versions -->
 		<maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
 		<maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
@@ -85,7 +85,7 @@
 					<artifactId>maven-compiler-plugin</artifactId>
 					<version>${maven-compiler-plugin.version}</version>
 					<configuration>
-						<release>${java.version}</release>
+						<release>${maven.compiler.target}</release>
 					</configuration>
 				</plugin>
 				<plugin>


### PR DESCRIPTION
Through use of https://github.com/joshlong/java-version-export-github-action
There's no hen-and-egg problem because GitHub's action runner image already ships with a JDK and Maven, and any version will do to just read the configured property from the POM.  
That \(major version part of the\) value is then used in the `setup-java` action, so they'll always be consistent.  
Adds about 30 seconds to the build.

---
<!-- Git and GitHub -->
- [ ] The main commit(s) reference the Fibery ticket via a `TASK-NNNN` prefix in the commit message subject
- [X] Include a human-readable description of what the pull request is trying to accomplish
- [X] The CI build passes
---
<!-- Testing; only one of the following needs to be checked: -->
- [ ] New automated tests have been added
- [ ] The changes are already covered by automated tests and have been adapted
- [ ] These manual test cases cover this change:
- [ ] Steps for the reviewer(s) on how they can manually QA the changes:
- [X] This is a minor internal change; basic CI/CD coverage is enough
- [ ] This is an incomplete feature hidden behind feature flag:
- [ ] This is proof-of-concept / experimental code not for production / marked `@Deprecated`
- [X] No (significant) changes to production code
---
<!-- Documentation -->
- [ ] ~~Classes and public methods have documentation (that doesn't just repeat the technical subject in English)~~
- [ ] ~~Logging is implemented to monitor feature usage and troubleshoot problems in production~~
- [ ] ~~These ReWiki pages are affected by this change and will be adapted:~~