### PR TITLE
Bump: Minor: Maven plugin updates

### DIFF
--- a/configs/pom.xml
+++ b/configs/pom.xml
@@ -16,7 +16,7 @@
 
 	<properties>
 		<!-- project version -->
-		<revision>1.7.4</revision>
+		<revision>1.8.0</revision>
 		<changelist>-SNAPSHOT</changelist>
 	</properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
 	<properties>
 		<!-- project version -->
-		<revision>1.7.4</revision>
+		<revision>1.8.0</revision>
 		<changelist>-SNAPSHOT</changelist>
 		<!-- dependencyManagement versions -->
 		<jetbrains-annotations.version>24.1.0</jetbrains-annotations.version>
@@ -29,16 +29,16 @@
 		<!-- pluginManagement -->
 		<maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>
 		<maven-surefire-report-plugin.version>3.3.0</maven-surefire-report-plugin.version>
-		<maven-failsafe-plugin.version>3.3.0</maven-failsafe-plugin.version>
+		<maven-failsafe-plugin.version>3.4.0</maven-failsafe-plugin.version>
 		<maven-source-plugin.version>3.3.1</maven-source-plugin.version>
 		<maven-javadoc-plugin.version>3.7.0</maven-javadoc-plugin.version>
 		<maven-shade-plugin.version>3.6.0</maven-shade-plugin.version>
 		<editorconfig-maven-plugin.version>0.1.3</editorconfig-maven-plugin.version> <!-- XXX: Remove linter dependency overrides when
 		upgrading from 0.1.3 -->
-		<maven-pmd-plugin.version>3.23.0</maven-pmd-plugin.version>
+		<maven-pmd-plugin.version>3.24.0</maven-pmd-plugin.version>
 		<pmd-core.version>7.1.0</pmd-core.version>
 		<pmd-java.version>7.1.0</pmd-java.version>
-		<spotbugs-maven-plugin.version>4.8.6.1</spotbugs-maven-plugin.version>
+		<spotbugs-maven-plugin.version>4.8.6.2</spotbugs-maven-plugin.version>
 		<maven-checkstyle-plugin.version>3.4.0</maven-checkstyle-plugin.version>
 		<checkstyle.version>10.17.0</checkstyle.version>
 		<maven-project-info-reports-plugin.version>3.6.1</maven-project-info-reports-plugin.version>

--- a/versions/pom.xml
+++ b/versions/pom.xml
@@ -18,7 +18,7 @@
 
 	<properties>
 		<!-- project version -->
-		<revision>1.7.4</revision>
+		<revision>1.8.0</revision>
 		<changelist>-SNAPSHOT</changelist>
 		<!-- project settings -->
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -27,12 +27,12 @@
 		<maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
 		<maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
 		<maven-dependency-plugin.version>3.7.1</maven-dependency-plugin.version>
-		<maven-release-plugin.version>3.1.0</maven-release-plugin.version>
+		<maven-release-plugin.version>3.1.1</maven-release-plugin.version>
 		<maven-clean-plugin.version>3.4.0</maven-clean-plugin.version>
 		<maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
 		<maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
 		<maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
-		<maven-surefire-plugin.version>3.3.0</maven-surefire-plugin.version>
+		<maven-surefire-plugin.version>3.4.0</maven-surefire-plugin.version>
 		<maven-install-plugin.version>3.1.2</maven-install-plugin.version>
 		<maven-deploy-plugin.version>3.1.2</maven-deploy-plugin.version>
 		<maven-site-plugin.version>4.0.0-M15</maven-site-plugin.version>


### PR DESCRIPTION
Bump maven-surefire-plugin from 3.3.0 to 3.4.0
Bump maven-failsafe-plugin from 3.3.0 to 3.4.0
Bump spotbugs-maven-plugin from 4.8.6.1 to 4.8.6.2 Bump maven-release-plugin from 3.1.0 to 3.1.1
Bump maven-pmd-plugin from 3.23.0 to 3.24.0

<!-- TODO: Please describe your changes here. -->

---
<!-- Git and GitHub -->
- [ ] The main commit(s) reference the Fibery ticket via a `TASK-NNNN` prefix in the commit message subject
- [ ] Include a human-readable description of what the pull request is trying to accomplish
- [ ] The CI build passes
---
<!-- Testing; only one of the following needs to be checked: -->
- [ ] New automated tests have been added
- [ ] The changes are already covered by automated tests and have been adapted
- [ ] These manual test cases cover this change:
- [ ] Steps for the reviewer(s) on how they can manually QA the changes:
- [ ] This is a minor internal change; basic CI/CD coverage is enough
- [ ] This is an incomplete feature hidden behind feature flag:
- [ ] This is proof-of-concept / experimental code not for production / marked `@Deprecated`
- [ ] No (significant) changes to production code
---
<!-- Documentation -->
- [ ] Classes and public methods have documentation (that doesn't just repeat the technical subject in English)
- [ ] Logging is implemented to monitor feature usage and troubleshoot problems in production
- [ ] These ReWiki pages are affected by this change and will be adapted:
