### PR TITLE
Bump: Minor: Maven plugin updates and PMD

### DIFF
--- a/configs/pmd-ruleset.xml
+++ b/configs/pmd-ruleset.xml
@@ -60,6 +60,7 @@
 	<rule ref="category/java/bestpractices.xml/UnusedPrivateField"/>
 	<rule ref="category/java/bestpractices.xml/UnusedPrivateMethod"/>
 	<rule ref="category/java/bestpractices.xml/UseCollectionIsEmpty"/>
+	<rule ref="category/java/bestpractices.xml/UseEnumCollections" />
 	<rule ref="category/java/bestpractices.xml/UseStandardCharsets"/>
 	<rule ref="category/java/bestpractices.xml/UseTryWithResources"/>
 	<rule ref="category/java/bestpractices.xml/UseVarargs"/>
@@ -259,7 +260,6 @@
 	<rule ref="category/java/errorprone.xml/AvoidLosingExceptionInformation"/>
 	<rule ref="category/java/errorprone.xml/AvoidMultipleUnaryOperators"/>
 	<rule ref="category/java/errorprone.xml/AvoidUsingOctalValues"/>
-	<rule ref="category/java/errorprone.xml/ComparisonWithNaN"/>
 	<rule ref="category/java/errorprone.xml/BrokenNullCheck"/>
 	<rule ref="category/java/errorprone.xml/CallSuperFirst"/>
 	<rule ref="category/java/errorprone.xml/CallSuperLast"/>
@@ -270,6 +270,7 @@
 	<rule ref="category/java/errorprone.xml/CloneMethodReturnTypeMustMatchClassName"/>
 	<rule ref="category/java/errorprone.xml/CloseResource"/>
 	<rule ref="category/java/errorprone.xml/CompareObjectsWithEquals"/>
+	<rule ref="category/java/errorprone.xml/ComparisonWithNaN"/>
 	<rule ref="category/java/errorprone.xml/ConfusingArgumentToVarargsMethod" />
 	<rule ref="category/java/errorprone.xml/ConstructorCallsOverridableMethod"/>
 	<rule ref="category/java/errorprone.xml/DetachedTestCase"/>
@@ -288,6 +289,7 @@
 	<rule ref="category/java/errorprone.xml/FinalizeOverloaded"/>
 	<rule ref="category/java/errorprone.xml/FinalizeShouldBeProtected"/>
 	<rule ref="category/java/errorprone.xml/IdempotentOperations"/>
+	<rule ref="category/java/errorprone.xml/ImplicitSwitchFallThrough"/>
 	<rule ref="category/java/errorprone.xml/InstantiationToGetClass"/>
 	<rule ref="category/java/errorprone.xml/InvalidLogMessageFormat"/>
 	<rule ref="category/java/errorprone.xml/JumbledIncrementer"/>
@@ -295,7 +297,6 @@
 	<rule ref="category/java/errorprone.xml/JUnitStaticSuite"/>
 	<rule ref="category/java/errorprone.xml/MethodWithSameNameAsEnclosingClass"/>
 	<rule ref="category/java/errorprone.xml/MisplacedNullCheck"/>
-	<rule ref="category/java/errorprone.xml/ImplicitSwitchFallThrough"/>
 	<rule ref="category/java/errorprone.xml/MissingSerialVersionUID"/>
 	<rule ref="category/java/errorprone.xml/MissingStaticMethodInNonInstantiatableClass"/>
 	<rule ref="category/java/errorprone.xml/MoreThanOneLogger"/>
@@ -329,6 +330,7 @@
 	<rule ref="category/java/errorprone.xml/UseProperClassLoader"/>
 
 	<rule ref="category/java/multithreading.xml/AvoidSynchronizedAtMethodLevel"/>
+	<rule ref="category/java/multithreading.xml/AvoidSynchronizedStatement" />
 	<rule ref="category/java/multithreading.xml/AvoidThreadGroup"/>
 	<rule ref="category/java/multithreading.xml/AvoidUsingVolatile"/>
 	<rule ref="category/java/multithreading.xml/DoNotUseThreads"/>

--- a/configs/pom.xml
+++ b/configs/pom.xml
@@ -16,7 +16,7 @@
 
 	<properties>
 		<!-- project version -->
-		<revision>1.8.0</revision>
+		<revision>1.9.0</revision>
 		<changelist>-SNAPSHOT</changelist>
 	</properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
 	<properties>
 		<!-- project version -->
-		<revision>1.8.0</revision>
+		<revision>1.9.0</revision>
 		<changelist>-SNAPSHOT</changelist>
 		<!-- dependencyManagement versions -->
 		<jetbrains-annotations.version>24.1.0</jetbrains-annotations.version>
@@ -28,7 +28,7 @@
 		<mockito.version>5.12.0</mockito.version>
 		<!-- pluginManagement -->
 		<maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>
-		<maven-surefire-report-plugin.version>3.3.0</maven-surefire-report-plugin.version>
+		<maven-surefire-report-plugin.version>3.5.0</maven-surefire-report-plugin.version>
 		<maven-failsafe-plugin.version>3.4.0</maven-failsafe-plugin.version>
 		<maven-source-plugin.version>3.3.1</maven-source-plugin.version>
 		<maven-javadoc-plugin.version>3.7.0</maven-javadoc-plugin.version>
@@ -36,15 +36,15 @@
 		<editorconfig-maven-plugin.version>0.1.3</editorconfig-maven-plugin.version> <!-- XXX: Remove linter dependency overrides when
 		upgrading from 0.1.3 -->
 		<maven-pmd-plugin.version>3.24.0</maven-pmd-plugin.version>
-		<pmd-core.version>7.1.0</pmd-core.version>
-		<pmd-java.version>7.1.0</pmd-java.version>
+		<pmd-core.version>7.5.0</pmd-core.version>
+		<pmd-java.version>7.5.0</pmd-java.version>
 		<spotbugs-maven-plugin.version>4.8.6.2</spotbugs-maven-plugin.version>
 		<maven-checkstyle-plugin.version>3.4.0</maven-checkstyle-plugin.version>
 		<checkstyle.version>10.17.0</checkstyle.version>
 		<maven-project-info-reports-plugin.version>3.6.1</maven-project-info-reports-plugin.version>
 		<maven-jxr-plugin.version>3.4.0</maven-jxr-plugin.version>
 		<cobertura-maven-plugin.version>2.7</cobertura-maven-plugin.version>
-		<pitest-maven.version>1.16.1</pitest-maven.version>
+		<pitest-maven.version>1.16.2</pitest-maven.version>
 		<pitest-junit5-plugin.version>1.2.1</pitest-junit5-plugin.version>
 		<versions-maven-plugin.version>2.17.0</versions-maven-plugin.version>
 		<maven-wrapper.version>3.3.2</maven-wrapper.version>

--- a/versions/pom.xml
+++ b/versions/pom.xml
@@ -18,7 +18,7 @@
 
 	<properties>
 		<!-- project version -->
-		<revision>1.8.0</revision>
+		<revision>1.9.0</revision>
 		<changelist>-SNAPSHOT</changelist>
 		<!-- project settings -->
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -26,7 +26,7 @@
 		<!-- plugin versions -->
 		<maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
 		<maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
-		<maven-dependency-plugin.version>3.7.1</maven-dependency-plugin.version>
+		<maven-dependency-plugin.version>3.8.0</maven-dependency-plugin.version>
 		<maven-release-plugin.version>3.1.1</maven-release-plugin.version>
 		<maven-clean-plugin.version>3.4.0</maven-clean-plugin.version>
 		<maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>


### PR DESCRIPTION
Bump maven-dependency-plugin from 3.7.1 to 3.8.0
Bump maven-surefire-report-plugin from 3.3.0 to 3.5.0 Bump pitest-maven from 1.16.1 to 1.16.2
Bump pmd from 7.1.0 to 7.5.0

<!-- TODO: Please describe your changes here. -->

---
<!-- Git and GitHub -->
- [ ] The main commit(s) reference the Fibery ticket via a `TASK-NNNN` prefix in the commit message subject
- [x] Include a human-readable description of what the pull request is trying to accomplish
- [x] The CI build passes
---
<!-- Testing; only one of the following needs to be checked: -->
- [ ] New automated tests have been added
- [ ] The changes are already covered by automated tests and have been adapted
- [ ] These manual test cases cover this change:
- [ ] Steps for the reviewer(s) on how they can manually QA the changes:
- [ ] This is a minor internal change; basic CI/CD coverage is enough
- [ ] This is an incomplete feature hidden behind feature flag:
- [ ] This is proof-of-concept / experimental code not for production / marked `@Deprecated`
- [ ] No (significant) changes to production code
---
<!-- Documentation -->
- [ ] Classes and public methods have documentation (that doesn't just repeat the technical subject in English)
- [ ] Logging is implemented to monitor feature usage and troubleshoot problems in production
- [ ] These ReWiki pages are affected by this change and will be adapted:
