### PR TITLE
Update versions and dump version to 2.1

### DIFF
--- a/configs/pmd-ruleset.xml
+++ b/configs/pmd-ruleset.xml
@@ -28,6 +28,7 @@
 	<rule ref="category/java/bestpractices.xml/ConstantsInInterface"/>
 	<rule ref="category/java/bestpractices.xml/DefaultLabelNotLastInSwitch"/>
 	<rule ref="category/java/bestpractices.xml/DoubleBraceInitialization"/>
+	<rule ref="category/java/bestpractices.xml/ExhaustiveSwitchHasDefault" />
 	<rule ref="category/java/bestpractices.xml/ForLoopCanBeForeach"/>
 	<rule ref="category/java/bestpractices.xml/ForLoopVariableCount"/>
 	<!--<rule ref="category/java/bestpractices.xml/GuardLogStatement"/>-->

--- a/configs/pom.xml
+++ b/configs/pom.xml
@@ -16,7 +16,7 @@
 
 	<properties>
 		<!-- project version -->
-		<revision>2.0.0</revision>
+		<revision>2.1.0</revision>
 		<changelist>-SNAPSHOT</changelist>
 	</properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,11 +18,11 @@
 
 	<properties>
 		<!-- project version -->
-		<revision>2.0.0</revision>
+		<revision>2.1.0</revision>
 		<changelist>-SNAPSHOT</changelist>
 		<!-- dependencyManagement versions -->
-		<jetbrains-annotations.version>26.0.1</jetbrains-annotations.version>
-		<spotbugs-annotations.version>4.8.6</spotbugs-annotations.version>
+		<jetbrains-annotations.version>26.0.2</jetbrains-annotations.version>
+		<spotbugs-annotations.version>4.9.0</spotbugs-annotations.version>
 		<hamcrest.version>3.0</hamcrest.version>
 		<junit.version>5.11.4</junit.version>
 		<mockito.version>5.15.2</mockito.version>
@@ -36,15 +36,15 @@
 		<editorconfig-maven-plugin.version>0.1.3</editorconfig-maven-plugin.version> <!-- XXX: Remove linter dependency overrides when
 		upgrading from 0.1.3 -->
 		<maven-pmd-plugin.version>3.26.0</maven-pmd-plugin.version>
-		<pmd-core.version>7.9.0</pmd-core.version>
-		<pmd-java.version>7.9.0</pmd-java.version>
+		<pmd-core.version>7.10.0</pmd-core.version>
+		<pmd-java.version>7.10.0</pmd-java.version>
 		<spotbugs-maven-plugin.version>4.8.6.6</spotbugs-maven-plugin.version>
 		<maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
-		<checkstyle.version>10.21.1</checkstyle.version>
+		<checkstyle.version>10.21.2</checkstyle.version>
 		<maven-project-info-reports-plugin.version>3.8.0</maven-project-info-reports-plugin.version>
 		<maven-jxr-plugin.version>3.6.0</maven-jxr-plugin.version>
 		<cobertura-maven-plugin.version>2.7</cobertura-maven-plugin.version>
-		<pitest-maven.version>1.17.3</pitest-maven.version>
+		<pitest-maven.version>1.17.4</pitest-maven.version>
 		<pitest-junit5-plugin.version>1.2.1</pitest-junit5-plugin.version>
 		<versions-maven-plugin.version>2.18.0</versions-maven-plugin.version>
 		<maven-wrapper.version>3.3.2</maven-wrapper.version>

--- a/versions/pom.xml
+++ b/versions/pom.xml
@@ -18,7 +18,7 @@
 
 	<properties>
 		<!-- project version -->
-		<revision>2.0.0</revision>
+		<revision>2.1.0</revision>
 		<changelist>-SNAPSHOT</changelist>
 		<!-- project settings -->
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -34,7 +34,7 @@
 		<maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
 		<maven-surefire-plugin.version>3.5.2</maven-surefire-plugin.version>
 		<maven-install-plugin.version>3.1.3</maven-install-plugin.version>
-		<maven-deploy-plugin.version>3.1.2</maven-deploy-plugin.version>
+		<maven-deploy-plugin.version>3.1.3</maven-deploy-plugin.version>
 		<maven-site-plugin.version>4.0.0-M16</maven-site-plugin.version>
 		<flatten-maven-plugin.version>1.6.0</flatten-maven-plugin.version>
 	</properties>


### PR DESCRIPTION
- pmd 7.10.0 -> new https://docs.pmd-code.org/pmd-doc-7.10.0/pmd_rules_java_bestpractices.html#exhaustiveswitchhasdefault

<!-- TODO: Please describe your changes here. -->

---
<!-- Git and GitHub -->
- [ ] The main commit(s) reference the Fibery ticket via a `TASK-NNNN` prefix in the commit message subject
- [x] Include a human-readable description of what the pull request is trying to accomplish
- [x] The CI build passes
---
<!-- Testing; only one of the following needs to be checked: -->
- [ ] New automated tests have been added
- [ ] The changes are already covered by automated tests and have been adapted
- [ ] These manual test cases cover this change:
- [ ] Steps for the reviewer(s) on how they can manually QA the changes:
- [ ] This is a minor internal change; basic CI/CD coverage is enough
- [ ] This is an incomplete feature hidden behind feature flag:
- [ ] This is proof-of-concept / experimental code not for production / marked `@Deprecated`
- [ ] No (significant) changes to production code
---
<!-- Documentation -->
- [ ] Classes and public methods have documentation (that doesn't just repeat the technical subject in English)
- [ ] Logging is implemented to monitor feature usage and troubleshoot problems in production
- [ ] These ReWiki pages are affected by this change and will be adapted:
