### PR TITLE
Disabled rule US_USELESS_SUPPRESSION_ON_METHOD in spotbugs

### DIFF
--- a/configs/pom.xml
+++ b/configs/pom.xml
@@ -16,7 +16,7 @@
 
 	<properties>
 		<!-- project version -->
-		<revision>2.5.0</revision>
+		<revision>2.5.1</revision>
 		<changelist>-SNAPSHOT</changelist>
 	</properties>
 

--- a/configs/spotbugs-exclude.xml
+++ b/configs/spotbugs-exclude.xml
@@ -14,4 +14,8 @@
 		<!-- https://github.com/spotbugs/spotbugs/issues/1338 -->
 		<Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"/>
 	</Match>
+	<Match>
+		<!-- https://github.com/spotbugs/spotbugs/issues/2965 -->
+		<Bug pattern="US_USELESS_SUPPRESSION_ON_METHOD"/>
+	</Match>
 </FindBugsFilter>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
 	<properties>
 		<!-- project version -->
-		<revision>2.5.0</revision>
+		<revision>2.5.1</revision>
 		<changelist>-SNAPSHOT</changelist>
 		<!-- project test groups -->
 		<includedSurefireGroups>none() | any()</includedSurefireGroups>

--- a/versions/pom.xml
+++ b/versions/pom.xml
@@ -18,7 +18,7 @@
 
 	<properties>
 		<!-- project version -->
-		<revision>2.5.0</revision>
+		<revision>2.5.1</revision>
 		<changelist>-SNAPSHOT</changelist>
 		<!-- project settings -->
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
<!-- TODO: Please describe your changes here. -->

---
<!-- Git and GitHub -->
- [ ] The main commit(s) reference the Fibery ticket via a `TASK-NNNN` prefix in the commit message subject
- [x] Include a human-readable description of what the pull request is trying to accomplish
- [x] The CI build passes
---
<!-- Testing; only one of the following needs to be checked: -->
- [ ] New automated tests have been added
- [ ] The changes are already covered by automated tests and have been adapted
- [ ] These manual test cases cover this change:
- [ ] Steps for the reviewer(s) on how they can manually QA the changes:
- [ ] This is a minor internal change; basic CI/CD coverage is enough
- [ ] This is an incomplete feature hidden behind feature flag:
- [ ] This is proof-of-concept / experimental code not for production / marked `@Deprecated`
- [ ] No (significant) changes to production code
---
<!-- Documentation -->
- [ ] Classes and public methods have documentation (that doesn't just repeat the technical subject in English)
- [ ] Logging is implemented to monitor feature usage and troubleshoot problems in production
- [ ] These ReWiki pages are affected by this change and will be adapted:
