### PR TITLE
updated maven plugins and added new rules

### DIFF
--- a/configs/pmd-ruleset.xml
+++ b/configs/pmd-ruleset.xml
@@ -56,6 +56,7 @@
 	<rule ref="category/java/bestpractices.xml/UnitTestShouldUseBeforeAnnotation"/>
 	<rule ref="category/java/bestpractices.xml/UnitTestShouldUseTestAnnotation"/>
 	<rule ref="category/java/bestpractices.xml/UnnecessaryVarargsArrayCreation"/>
+	<rule ref="category/java/bestpractices.xml/UnnecessaryWarningSuppression"/>
 	<rule ref="category/java/bestpractices.xml/UnusedAssignment"/>
 	<rule ref="category/java/bestpractices.xml/UnusedFormalParameter"/>
 	<rule ref="category/java/bestpractices.xml/UnusedLocalVariable"/>

--- a/configs/pom.xml
+++ b/configs/pom.xml
@@ -16,7 +16,7 @@
 
 	<properties>
 		<!-- project version -->
-		<revision>2.7.0</revision>
+		<revision>2.8.0</revision>
 		<changelist>-SNAPSHOT</changelist>
 	</properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
 	<properties>
 		<!-- project version -->
-		<revision>2.7.0</revision>
+		<revision>2.8.0</revision>
 		<changelist>-SNAPSHOT</changelist>
 		<!-- project test groups -->
 		<includedSurefireGroups>none() | any()</includedSurefireGroups>
@@ -31,8 +31,8 @@
 		<jetbrains-annotations.version>26.0.2</jetbrains-annotations.version>
 		<spotbugs-annotations.version>4.9.3</spotbugs-annotations.version>
 		<hamcrest.version>3.0</hamcrest.version>
-		<junit.version>5.12.2</junit.version>
-		<mockito.version>5.17.0</mockito.version>
+		<junit.version>5.13.0</junit.version>
+		<mockito.version>5.18.0</mockito.version>
 		<!-- pluginManagement -->
 		<maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>
 		<maven-surefire-report-plugin.version>3.5.3</maven-surefire-report-plugin.version>
@@ -43,16 +43,16 @@
 		<editorconfig-maven-plugin.version>0.1.3</editorconfig-maven-plugin.version> <!-- XXX: Remove linter dependency overrides when
 		upgrading from 0.1.3 -->
 		<maven-pmd-plugin.version>3.26.0</maven-pmd-plugin.version>
-		<pmd-core.version>7.13.0</pmd-core.version>
-		<pmd-java.version>7.13.0</pmd-java.version>
+		<pmd-core.version>7.14.0</pmd-core.version>
+		<pmd-java.version>7.14.0</pmd-java.version>
 		<spotbugs-maven-plugin.version>4.9.3.0</spotbugs-maven-plugin.version>
 		<maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
-		<checkstyle.version>10.23.1</checkstyle.version>
+		<checkstyle.version>10.25.0</checkstyle.version>
 		<maven-project-info-reports-plugin.version>3.9.0</maven-project-info-reports-plugin.version>
 		<maven-jxr-plugin.version>3.6.0</maven-jxr-plugin.version>
 		<cobertura-maven-plugin.version>2.7</cobertura-maven-plugin.version>
-		<pitest-maven.version>1.19.3</pitest-maven.version>
-		<pitest-junit5-plugin.version>1.2.2</pitest-junit5-plugin.version>
+		<pitest-maven.version>1.19.4</pitest-maven.version>
+		<pitest-junit5-plugin.version>1.2.3</pitest-junit5-plugin.version>
 		<versions-maven-plugin.version>2.18.0</versions-maven-plugin.version>
 		<maven-wrapper.version>3.3.2</maven-wrapper.version>
 	</properties>

--- a/versions/pom.xml
+++ b/versions/pom.xml
@@ -18,7 +18,7 @@
 
 	<properties>
 		<!-- project version -->
-		<revision>2.7.0</revision>
+		<revision>2.8.0</revision>
 		<changelist>-SNAPSHOT</changelist>
 		<!-- project settings -->
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -28,7 +28,7 @@
 		<maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
 		<maven-dependency-plugin.version>3.8.1</maven-dependency-plugin.version>
 		<maven-release-plugin.version>3.1.1</maven-release-plugin.version>
-		<maven-clean-plugin.version>3.4.1</maven-clean-plugin.version>
+		<maven-clean-plugin.version>3.5.0</maven-clean-plugin.version>
 		<maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
 		<maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
 		<maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
@@ -37,6 +37,7 @@
 		<maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
 		<maven-site-plugin.version>4.0.0-M16</maven-site-plugin.version>
 		<flatten-maven-plugin.version>1.7.0</flatten-maven-plugin.version>
+		<versions-maven-plugin.version>2.18.0</versions-maven-plugin.version>
 	</properties>
 
 	<distributionManagement>
@@ -109,6 +110,11 @@
 					<artifactId>flatten-maven-plugin</artifactId>
 					<version>${flatten-maven-plugin.version}</version>
 				</plugin>
+				<plugin>
+					<groupId>org.codehaus.mojo</groupId>
+					<artifactId>versions-maven-plugin</artifactId>
+					<version>${versions-maven-plugin.version}</version>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 		<plugins>
@@ -136,6 +142,13 @@
 						</goals>
 					</execution>
 				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>versions-maven-plugin</artifactId>
+				<configuration>
+					<ignoredVersions>(?i).*-(alpha|beta|m|rc)([-.]?\d+)?</ignoredVersions>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
- `make update-dependencies` now ignores non-releases (-beta, -m, -rc, )
- added new pmd rule `UnnecessaryWarningSuppression`

<!-- TODO: Please describe your changes here. -->

---
<!-- Git and GitHub -->
- [ ] The main commit(s) reference the Fibery ticket via a `TASK-NNNN` prefix in the commit message subject
- [x] Include a human-readable description of what the pull request is trying to accomplish
- [ ] The CI build passes
---
<!-- Testing; only one of the following needs to be checked: -->
- [ ] New automated tests have been added
- [ ] The changes are already covered by automated tests and have been adapted
- [ ] These manual test cases cover this change:
- [ ] Steps for the reviewer(s) on how they can manually QA the changes:
- [ ] This is a minor internal change; basic CI/CD coverage is enough
- [ ] This is an incomplete feature hidden behind feature flag:
- [ ] This is proof-of-concept / experimental code not for production / marked `@Deprecated`
- [ ] No (significant) changes to production code
---
<!-- Documentation -->
- [ ] Classes and public methods have documentation (that doesn't just repeat the technical subject in English)
- [ ] Logging is implemented to monitor feature usage and troubleshoot problems in production
- [ ] These ReWiki pages are affected by this change and will be adapted:
